### PR TITLE
fix: suffix /* at end of azure ingress prefix path

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -47,26 +47,30 @@ spec:
             name: {{ .Release.Name }}-api-svc
             port:
               number: 8080
-        path: /api
+        # Azure bug: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1238
+        path: {{ ternary "/api/*" "/api" (eq .Values.ingress.class "azure/application-gateway") | quote }}
         pathType: Prefix
       - backend:
           service:
             name: {{ .Release.Name }}-recording-svc
             port:
               number: 8080
-        path: /recording
+        # Azure bug: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1238
+        path: {{ ternary "/recording/*" "/recording" (eq .Values.ingress.class "azure/application-gateway") | quote }}
         pathType: Prefix
       - backend:
           service:
             name: {{ .Release.Name }}-proxy-svc
             port:
               number: 8080
-        path: /proxy
+        # Azure bug: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1238
+        path: {{ ternary "/proxy/*" "/proxy" (eq .Values.ingress.class "azure/application-gateway") | quote }}
         pathType: Prefix
       - backend:
           service:
             name: {{ .Release.Name }}-sockets-svc
             port:
               number: 8080
-        path: /sockets
+        # Azure bug: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1238
+        path: {{ ternary "/sockets/*" "/sockets" (eq .Values.ingress.class "azure/application-gateway") | quote }}
         pathType: Prefix


### PR DESCRIPTION
Applying a workaround for what appears to be this issue in the azure appgw ingress:

https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1238

I haven't sanity checked this along side other cloud deployments, but seems fairly safe. Will get GCP test coverage on it in coming days, though so feel free to hold off merge until I can verify that.