### PR TITLE
Adding override for secrets to be used differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.5.13](#) (2021-11-21)
+
+### Bug Fixes
+
+* **Image Pull Secret:** Allowing to override the `imagePullSecret` to use a custom name ([5a584e1](#))
+* **TLS Secret Name:** Allowing to set a custom name for the TLS `secretName` ([8e07bd9](#))
+* **Ingress with TLS:** Adding an option to have TLS on the `Ingress` without the need of `CertManager` ([dc8d624](#))
+* **Sensitive Secrets:** Moving sensitive secrets to be consumed with custom secret - `license_key` for example ([2198f76](#))
+
 ### [1.5.12](#) (2021-10-22)
 
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cobrowse-enterprise
-version: 1.5.12
+version: 1.5.13
 kubeVersion: ">=1.19.0-0"
 description: Helm Chart for Cobrowse Enterprise
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cobrowse-enterprise
 version: 1.5.13
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.18.0-0"
 description: Helm Chart for Cobrowse Enterprise
 keywords:
   - cobrowse-enterprise

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -30,3 +30,10 @@ Create imagepullsecretfor docker registry
 {{- printf "{\"auths\":{\"ghcr.io\":{\"username\":\"cobrowse-enterprise\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .password (printf "cobrowse-enterprise:%s" .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}
+
+{{/*
+The name of the secret for the ImagePullSecret
+*/}}
+{{- define "imagePullSecretName" }}
+{{- default (printf "%s-docker-cfg" .Release.Name) .Values.imageCredentials.pullSecretName }}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,3 +37,10 @@ The name of the secret for the ImagePullSecret
 {{- define "imagePullSecretName" }}
 {{- default (printf "%s-docker-cfg" .Release.Name) .Values.imageCredentials.pullSecretName }}
 {{- end }}
+
+{{/*
+The name of the TLS secret for the Ingress
+*/}}
+{{- define "tlsSecretName" }}
+{{- default "tls-secret" .Values.ssl.tls.name }}
+{{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -69,4 +69,4 @@ spec:
             cpu: {{ .Values.api.cpu | default "256m" }}
             memory: {{ .Values.api.memory | default "256Mi" }}
       imagePullSecrets:
-      - name: {{ .Release.Name }}-docker-cfg
+      - name: {{ template "imagePullSecretName" . }}

--- a/templates/api-secret.yaml
+++ b/templates/api-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +24,4 @@ data:
   streaming__locate_url: {{ printf "https://%s/sockets/1/region" .Values.domain | b64enc | quote }}
   license_key: {{ default "" .Values.license | b64enc | quote }}
   superusers: {{ default "" .Values.superusers | b64enc | quote }}
+{{- end }}

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: tls-secret
+  name: {{ template "tlsSecretName" . }}
   namespace: {{ .Release.Namespace | default "default" }}
   labels:
     app: {{ template "fullname" . }}
@@ -33,7 +33,7 @@ metadata:
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
 spec:
-  secretName: tls-secret
+  secretName: {{ template "tlsSecretName" . }}
   dnsNames:
     - {{ .Values.domain }}
   issuerRef:

--- a/templates/docker-cfg.yaml
+++ b/templates/docker-cfg.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.imageCredentials.disable }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/templates/docker-cfg.yaml
+++ b/templates/docker-cfg.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.imageCredentials.create }}
+{{- if .Values.imageCredentials.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/docker-cfg.yaml
+++ b/templates/docker-cfg.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.imageCredentials.disable }}
+{{- if not .Values.imageCredentials.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -65,4 +65,4 @@ spec:
             cpu: {{ .Values.frontend.cpu | default "256m"}}
             memory: {{ .Values.frontend.memory | default "256Mi"}}
       imagePullSecrets:
-      - name: {{ .Release.Name }}-docker-cfg
+      - name: {{ template "imagePullSecretName" . }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
       name: {{ .Release.Name }}-frontend-svc
       port:
         number: 8080
-{{- if eq .Values.ssl.generator "cert-manager" }}
+{{- if or (eq .Values.ssl.generator "cert-manager") .Values.ssl.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.domain }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -36,7 +36,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.domain }}
-    secretName: "tls-secret"
+    secretName: {{ template "tlsSecretName" . }}
 {{- end }}
   rules:
   - host: {{ .Values.domain }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -69,4 +69,4 @@ spec:
             cpu: {{ .Values.proxy.cpu | default "256m"}}
             memory: {{ .Values.proxy.memory | default "256Mi"}}
       imagePullSecrets:
-      - name: {{ .Release.Name }}-docker-cfg
+      - name: {{ template "imagePullSecretName" . }}

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -70,4 +70,4 @@ spec:
             cpu: {{ .Values.recording.cpu | default "256m"}}
             memory: {{ .Values.recording.memory | default "256Mi"}}
       imagePullSecrets:
-      - name: {{ .Release.Name }}-docker-cfg
+      - name: {{ template "imagePullSecretName" . }}

--- a/templates/sockets-secret.yaml
+++ b/templates/sockets-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,3 +20,4 @@ data:
   peering_token: {{ randAlphaNum 32 | b64enc | quote }}
   peering_hostname_template: {{ printf "<%%=hostname%%>.%s-sockets-headless" .Release.Name | b64enc | quote }}
   redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
+{{- end }}

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
             cpu: {{ .Values.sockets.cpu | default "256m"}}
             memory: {{ .Values.sockets.memory | default "256Mi"}}
       imagePullSecrets:
-      - name: {{ .Release.Name }}-docker-cfg
+      - name: {{ template "imagePullSecretName" . }}
       volumes:
       - name: data-traces
         persistentVolumeClaim:

--- a/values.yaml
+++ b/values.yaml
@@ -2,6 +2,7 @@
 
 imageCredentials:
   disabled: false
+  pullSecretName: ""
   password: ""
 
 domain: ""

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,9 @@ imageCredentials:
   password: ""
 
 domain: ""
+secret:
+  create: true
+
 license: ""
 superusers: ""
 mongo:

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,8 @@ redis:
   url: ""
 stage: "enterprise"
 ssl:
+  tls:
+    name: ""
   generator: ""
 
 # Kubernetes Ingress configuration

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,7 @@ redis:
 stage: "enterprise"
 ssl:
   tls:
+    enabled: false
     name: ""
   generator: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 # Common configurations
 
 imageCredentials:
-  disabled: false
+  create: false
   pullSecretName: ""
   password: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,7 @@
 # Common configurations
 
 imageCredentials:
+  disabled: false
   password: ""
 
 domain: ""

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 # Common configurations
 
 imageCredentials:
-  create: false
+  create: true
   pullSecretName: ""
   password: ""
 


### PR DESCRIPTION
The current use of the chart mandate that the secrets should be auto-created on installation.
However, this disabled us to use the `values.yaml` of our custom values inside the Source Control (since it contains sensitive information secrets).

This PR contains custom values to control the usage of the secrets, which will let us create the Secrets manually and differently (for example, Configuration Management and External Secret) on our clusters, and override the default behaviour.