### PR TITLE
feat: add pod label to select cobrowse enterprise services

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/api-secret.yaml") . | sha256sum }}
       labels:
+        app: {{ template "fullname" . }}
         component: api
         stage: {{ .Values.stage | quote }}
     spec:

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/frontend-secret.yaml") . | sha256sum }}
       labels:
+        app: {{ template "fullname" . }}
         component: frontend
         stage: {{ .Values.stage | quote }}
     spec:

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/proxy-secret.yaml") . | sha256sum }}
       labels:
+        app: {{ template "fullname" . }}
         component: proxy
         stage: {{ .Values.stage | quote }}
     spec:

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/recording-secret.yaml") . | sha256sum }}
       labels:
+        app: {{ template "fullname" . }}
         component: recording
         stage: {{ .Values.stage | quote }}
     spec:

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -54,6 +54,7 @@ spec:
         name: sockets
         ports:
         - containerPort: 8080
+          name: http
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/sockets-secret.yaml") . | sha256sum }}
       labels:
+        app: {{ template "fullname" . }}
         component: sockets
         stage: {{ .Values.stage | quote }}
     spec:


### PR DESCRIPTION
The GKE workload metrics podmonitor selects using matchLabel instead of matching annotations like prometheus. This labels allows selection of the cobrowse enterprise services on `app: cobrowse-cobrowse-enterprise`, and is selected in the samples for the cobrowse-enterprise-gcp sample podmonitor templates.

The podmonitor also requires that you reference the port by name, which was fine for all except the sockets server, which didn't have its http port named. I've added that in as well.