### PR TITLE
feat: allow for custom configmaps and secrets managed in kubernetes

### DIFF
--- a/templates/api-configmap.yaml
+++ b/templates/api-configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-api-envvars
+  namespace: {{ .Release.Namespace | default "default" }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    stage: {{ .Values.stage | quote }}
+data:
+  PORT: "8080"
+  STAGE: {{ .Values.stage | quote }}
+  DEBUG: {{ default "" .Values.api.debug | quote }}
+  frontend_url: {{ printf "https://%s" .Values.domain | quote }}
+  control__url_template: {{ printf "https://%s" .Values.domain | quote }}
+  streaming__url_template: {{ printf "https://%s" .Values.domain | quote }}
+  streaming__default_region: "api"
+  streaming__locate_url: {{ printf "https://%s/sockets/1/region" .Values.domain | quote }}
+  license_key: {{ default "" .Values.license | quote }}
+  superusers: {{ default "" .Values.superusers | b64enc | quote }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -32,8 +32,16 @@ spec:
     spec:
       containers:
       - envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-api-envvars
+        - configMapRef:
+            name: {{ .Release.Name }}-api-custom-envvars
+            optional: true
         - secretRef:
             name: {{ .Release.Name }}-api-envvars
+        - secretRef:
+            name: {{ .Release.Name }}-api-custom-envvars
+            optional: true
         image: {{ (.Values.api.image).ref | default "ghcr.io/cobrowseio/cobrowse-api-enterprise:1.12.1" }}
         imagePullPolicy: {{ (.Values.api.image).pullPolicy }}
         livenessProbe:

--- a/templates/api-secret.yaml
+++ b/templates/api-secret.yaml
@@ -11,15 +11,5 @@ metadata:
     stage: {{ .Values.stage | quote }}
 type: Opaque
 data:
-  PORT: {{ "8080" | b64enc | quote }}
-  STAGE: {{ .Values.stage | b64enc | quote }}
-  DEBUG: {{ default "" .Values.api.debug | b64enc | quote }}
   mongo_url: {{ default "" .Values.mongo.url | b64enc | quote }}
   redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
-  frontend_url: {{ printf "https://%s" .Values.domain | b64enc | quote }}
-  control__url_template: {{ printf "https://%s" .Values.domain | b64enc | quote }}
-  streaming__url_template: {{ printf "https://%s" .Values.domain | b64enc | quote }}
-  streaming__default_region: {{ default "api" | b64enc | quote }}
-  streaming__locate_url: {{ printf "https://%s/sockets/1/region" .Values.domain | b64enc | quote }}
-  license_key: {{ default "" .Values.license | b64enc | quote }}
-  superusers: {{ default "" .Values.superusers | b64enc | quote }}

--- a/templates/frontend-configmap.yaml
+++ b/templates/frontend-configmap.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-frontend-envvars
   namespace: {{ .Release.Namespace | default "default" }}
@@ -9,5 +9,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
-type: Opaque
-data: {}
+data:
+  COBROWSE_ENTERPRISE: "true"
+

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -32,8 +32,16 @@ spec:
     spec:
       containers:
       - envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-frontend-envvars
+        - configMapRef:
+            name: {{ .Release.Name }}-frontend-custom-envvars
+            optional: true
         - secretRef:
             name: {{ .Release.Name }}-frontend-envvars
+        - secretRef:
+            name: {{ .Release.Name }}-frontend-custom-envvars
+            optional: true
         image: {{ (.Values.frontend.image).ref | default "ghcr.io/cobrowseio/cobrowse-frontend-enterprise:2.9.0" }}
         imagePullPolicy: {{ (.Values.frontend.image).pullPolicy }}
         livenessProbe:

--- a/templates/proxy-configmap.yaml
+++ b/templates/proxy-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-frontend-envvars
+  name: {{ .Release.Name }}-proxy-envvars
   namespace: {{ .Release.Namespace | default "default" }}
   labels:
     app: {{ template "fullname" . }}
@@ -9,5 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
-type: Opaque
-data: {}
+data:
+  PORT: "8080"
+  STAGE: {{ default "" .Values.stage | quote }}
+  DEBUG: {{ default "" .Values.proxy.debug | quote }}
+  api_url: {{ printf "http://%s-api-svc:8080" .Release.Name | quote }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -32,8 +32,16 @@ spec:
     spec:
       containers:
       - envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-proxy-envvars
+        - configMapRef:
+            name: {{ .Release.Name }}-proxy-custom-envvars
+            optional: true
         - secretRef:
             name: {{ .Release.Name }}-proxy-envvars
+        - secretRef:
+            name: {{ .Release.Name }}-proxy-custom-envvars
+            optional: true
         image: {{ (.Values.proxy.image).ref | default "ghcr.io/cobrowseio/cobrowse-proxy-enterprise:1.1.9" }}
         imagePullPolicy: {{ (.Values.proxy.image).pullPolicy }}
         livenessProbe:

--- a/templates/proxy-secret.yaml
+++ b/templates/proxy-secret.yaml
@@ -10,8 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
 type: Opaque
-data:
-  PORT: {{ "8080" | b64enc | quote }}
-  STAGE: {{ default "" .Values.stage | b64enc | quote }}
-  DEBUG: {{ default "" .Values.proxy.debug | b64enc | quote }}
-  api_url: {{ printf "http://%s-api-svc:8080" .Release.Name | b64enc | quote }}
+data: {}

--- a/templates/recording-configmap.yaml
+++ b/templates/recording-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-frontend-envvars
+  name: {{ .Release.Name }}-recording-envvars
   namespace: {{ .Release.Namespace | default "default" }}
   labels:
     app: {{ template "fullname" . }}
@@ -9,5 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
-type: Opaque
-data: {}
+data:
+  PORT: "8080"
+  STAGE: {{ .Values.stage | quote }}
+  DEBUG: {{ default "" .Values.recording.debug | quote }}

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -33,8 +33,16 @@ spec:
     spec:
       containers:
       - envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-recording-envvars
+        - configMapRef:
+            name: {{ .Release.Name }}-recording-custom-envvars
+            optional: true
         - secretRef:
             name: {{ .Release.Name }}-recording-envvars
+        - secretRef:
+            name: {{ .Release.Name }}-recording-custom-envvars
+            optional: true
         image: {{ (.Values.recording.image).ref | default "ghcr.io/cobrowseio/cobrowse-recording-enterprise:1.0.11" }}
         imagePullPolicy: {{ (.Values.recording.image).pullPolicy }}
         livenessProbe:

--- a/templates/recording-secret.yaml
+++ b/templates/recording-secret.yaml
@@ -10,7 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
 type: Opaque
-data:
-  PORT: {{ "8080" | b64enc | quote }}
-  STAGE: {{ default "" .Values.stage | b64enc | quote }}
-  DEBUG: {{ default "" .Values.recording.debug | b64enc | quote }}
+data: {}

--- a/templates/sockets-configmap.yaml
+++ b/templates/sockets-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-sockets-envvars
+  namespace: {{ .Release.Namespace | default "default" }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    stage: {{ .Values.stage | quote }}
+data:
+  PORT: "8080"
+  STAGE: {{ default "" .Values.stage | quote }}
+  DEBUG: {{ default "" .Values.sockets.debug | quote }}
+  api_url: {{ printf "http://%s-api-svc:8080" .Release.Name | quote }}
+  peering_port: "8081"
+  peering_hostname_template: {{ printf "<%%=hostname%%>.%s-sockets-headless" .Release.Name | quote }}

--- a/templates/sockets-secret.yaml
+++ b/templates/sockets-secret.yaml
@@ -11,11 +11,5 @@ metadata:
     stage: {{ .Values.stage | quote }}
 type: Opaque
 data:
-  PORT: {{ "8080" | b64enc | quote }}
-  STAGE: {{ default "" .Values.stage | b64enc | quote }}
-  DEBUG: {{ default "" .Values.sockets.debug | b64enc | quote }}
-  api_url: {{ printf "http://%s-api-svc:8080" .Release.Name | b64enc | quote }}
-  peering_port: {{ "8081" | b64enc | quote }}
   peering_token: {{ randAlphaNum 32 | b64enc | quote }}
-  peering_hostname_template: {{ printf "<%%=hostname%%>.%s-sockets-headless" .Release.Name | b64enc | quote }}
   redis_url: {{ default "" .Values.redis.url | b64enc | quote }}

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -36,8 +36,16 @@ spec:
 {{- end }}
       containers:
       - envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-sockets-envvars
+        - configMapRef:
+            name: {{ .Release.Name }}-sockets-custom-envvars
+            optional: true
         - secretRef:
             name: {{ .Release.Name }}-sockets-envvars
+        - secretRef:
+            name: {{ .Release.Name }}-sockets-custom-envvars
+            optional: true
         image: {{ (.Values.sockets.image).ref | default "ghcr.io/cobrowseio/cobrowse-api-sockets-enterprise:1.2.11" }}
         imagePullPolicy: {{ (.Values.sockets.image).pullPolicy }}
         livenessProbe:


### PR DESCRIPTION
As discussed, each service has:

 * Required internal configmap that we provide with non-secret values
 * Optional custom configmap for non-secret values that overrides the internal configmap
 * Required internal secrets that we provide with secret values (some are empty, but seemed reasonable to just keep the pattern). This overrides all the envvar configmaps
 * Optional custom secret for secret values that overrides the internal secret values and all envvar configmaps

Non-secret values have been ported over to the internal configmaps.