### PR TITLE
chore: generate changelogs for each component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.release-notes.tmpl.md

--- a/.helmignore
+++ b/.helmignore
@@ -1,2 +1,5 @@
 .git
+.release-notes.tmpl.md
+.vscode
 packages
+scripts

--- a/.versionrc.js
+++ b/.versionrc.js
@@ -15,7 +15,10 @@ module.exports = {
   packageFiles: [tracker],
   bumpFiles: [tracker],
   scripts: {
-    postbump: "helm package . -d packages && helm repo index packages --url https://cobrowseio.github.io/cobrowse-enterprise-helm/packages ; git add packages ; git commit -m \"build(helm): package helm chart\""
+    prebump:
+      './scripts/ensure-github-token.sh && ./scripts/generate-component-changelog.sh > .release-notes.tmpl.md',
+    postbump:
+      'helm package . -d packages && helm repo index packages --url https://cobrowseio.github.io/cobrowse-enterprise-helm/packages ; git add packages ; git commit -m "build(helm): package helm chart" ; sed "s/{VERSION}/$(./scripts/get-chart-version.sh)/" .release-notes.tmpl.md | hub release create -d -F- v$(./scripts/get-chart-version.sh)',
   },
   commitUrlFormat: "#",
   compareUrlFormat: "#",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "eslint.enable": false,
+  "prettier.enable": false,
+  "standard.enable": true,
+  "standard.autoFixOnSave": true,
+  "standard.engine": "standard",
+  "[yaml]": {
+    "editor.formatOnSave": false
+  },
+  "[dockerfile]": {
+    "editor.formatOnSave": false
+  }
+}

--- a/scripts/ensure-github-token.sh
+++ b/scripts/ensure-github-token.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash -e
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "You must have GITHUB_TOKEN set with repo access" 1>&2
+  exit 1
+fi

--- a/scripts/generate-component-changelog.sh
+++ b/scripts/generate-component-changelog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash -e
+
+##
+# Output a changelog for each referenced service component as-of the previous
+# released version of this Chart.
+#
+# When running this script, the "previous released version" of the chart is
+# considered to be what is found in the `Chart.yaml` `version: <version>`
+# property in the current working copy. If you need to pull changelogs from
+# an older version, use the -v flag to specify an older version of the chart.
+#
+# # How it works
+#
+# This script will discover the old versions of by grepping their
+# kubernetes descriptor file: `api-deployment.yaml`, `sockets-statefulset.yaml`,
+# and so on. To get an older version of a file, it will be extracted from the
+# git version tag at the specified version.
+#
+# Arguments:
+#
+# `--next-version`: The next version of the helm chart being released
+# `--prev-version`: The source version from which to get component version
+#                   references. If unspecified, will use the version specified
+#                   in the working copy of `Chart.yaml`. This is usually what
+#                   you want.
+##
+
+HELM_NEXT_VERSION=""
+HELM_PREV_VERSION=$(./scripts/get-chart-version.sh)
+
+usage() { echo "Usage: $0 [--prev-version <helm chart version (default: $HELM_PREV_VERSION)>]" 1>&2; exit 1; }
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    "-p" | "--prev-version")
+      shift
+      HELM_PREV_VERSION="$1"
+      ;;
+    *)
+      usage
+  esac
+  shift
+done
+
+output_changelog () {
+  local OUT="$(./scripts/get-component-commits.sh -r $1 -c $2 -v $HELM_PREV_VERSION)"
+  if [ -n "$OUT" ]; then
+    echo "$OUT"
+  else
+    echo "No changes."
+  fi
+}
+
+echo "Release v{VERSION}"
+echo ""
+echo "## Features"
+echo "[features]"
+echo ""
+echo "## Bug Fixes"
+echo "[fixes]"
+echo ""
+echo "## Breaking changes"
+echo "[breaking changes]"
+echo ""
+echo "## Deployment instructions "
+echo "Run \`helm upgrade\`"
+echo ""
+echo "## Detailed changes"
+echo ""
+echo "### Cobrowse Enterprise Helm"
+git log --pretty=format:"* %s (%h)" --first-parent "v$HELM_PREV_VERSION...HEAD"
+echo ""
+echo "### Cobrowse Enterprise API"
+output_changelog cobrowse-api api-deployment $HELM_PREV_VERSION
+echo ""
+echo "### Cobrowse Enterprise Sockets"
+output_changelog cobrowse-api-sockets sockets-statefulset $HELM_PREV_VERSION
+echo ""
+echo "### Cobrowse Enterprise Proxy"
+output_changelog cobrowse-proxy proxy-deployment $HELM_PREV_VERSION
+echo ""
+echo "### Cobrowse Enterprise Recording"
+output_changelog cobrowse-recording recording-deployment $HELM_PREV_VERSION
+echo ""
+echo "### Cobrowse Enterprise Frontend"
+output_changelog cobrowse-frontend frontend-deployment $HELM_PREV_VERSION

--- a/scripts/get-chart-version.sh
+++ b/scripts/get-chart-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash -e
+
+grep 'version:' Chart.yaml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+"

--- a/scripts/get-component-commits.sh
+++ b/scripts/get-component-commits.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash -e
+
+##
+# Output the commits that have been merged to a service component repository as-
+# of the specified chart version.
+#
+# # How it works
+#
+# This script will discover the old versions of by grepping their
+# kubernetes descriptor file (component): `api-deployment.yaml`,
+# `sockets-statefulset.yaml`, and so on. To get an older version of a file, it
+# will be extracted from the git version tag at the specified version.
+#
+# Arguments:
+#
+#      `--repo`: The repository name of the component service (under the
+#                cobrowseio namespace)
+# `--component`: The name of the component file from which to extract the
+#                current and previous referenced version
+#   `--version`: The source version from which to get component version
+#                references. If unspecified, will use the version specified in
+#                the working copy of `Chart.yaml`. This is usually what you want.
+##
+
+usage() { echo "Usage: $0 --repo <repo name (e.g., cobrowse-api)> --component <name (one of: api-deployment, proxy-deployment, recording-deployment, sockets-statefulset)> --version <helm chart version (e.g., 1.2.3)>]" 1>&2; exit 1; }
+
+REPO=""
+COMPONENT=""
+CHART_VERSION=""
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    "-r" | "--repo")
+      shift
+      REPO="$1"
+      ;;
+    "-v" | "--version")
+      shift
+      CHART_VERSION="$1"
+      ;;
+    "-c" | "--component")
+      shift
+      COMPONENT="$1"
+      ;;
+    *)
+      usage
+  esac
+  shift
+done
+
+if [ -z "$REPO" ]; then
+  echo "Must specify a repo (--repo)." 1>&2
+  usage
+fi
+
+if [ -z "$COMPONENT" ]; then
+  echo "Must specify a component (--component)." 1>&2
+  usage
+fi
+
+if [ -z "$CHART_VERSION" ]; then
+  echo "Must specify the beginning helm chart version (--version)." 1>&2
+  usage
+fi
+
+GIT_URL="https://$COBROWSEIO_GITHUB_TOKEN@github.com/cobrowseio/$REPO.git"
+GIT_DIR="/tmp/.$COMPONENT.git"
+
+FROM=$(./scripts/get-component-version.sh -c "$COMPONENT" -v "$CHART_VERSION")
+TO=$(./scripts/get-component-version.sh -c "$COMPONENT")
+
+rm -rf "$GIT_DIR"
+git clone -q --filter=blob:none --bare "$GIT_URL" "$GIT_DIR"
+git --git-dir "$GIT_DIR" log --pretty=format:"* %s (%h)" --first-parent "v$FROM...v$TO"

--- a/scripts/get-component-version.sh
+++ b/scripts/get-component-version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash -e
+
+##
+# Given a Chart version, get the version of the component service linked in the
+# deployment.
+#
+# Arguments:
+#   `--component`: The name of the file that contains the version reference to
+#                  the component.
+#     `--version`: The version of the Chart whose component version reference to
+#                  extract. If unspecified, it will take the version from the
+#                  local working copy. This version must represent a previously
+#                  tagged version (excluding the preceding 'v')
+#
+# Examples:
+#
+# Get the current version referenced for the recording deployment:
+# `$ ./scripts/get-component-version.sh -c recording-deployment`
+#
+# Get the version referenced for the api sockets deployment in Chart version v1.5.10:
+# `$ ./scripts/get-component-version.sh -c sockets-statefulset -v 1.5.10`
+##
+
+usage() { echo "Usage: $0 --component <name (one of: api-deployment, proxy-deployment, recording-deployment, sockets-statefulset)> [--version <helm chart version (e.g., 1.2.3)>]" 1>&2; exit 1; }
+
+COMPONENT=""
+CHART_VERSION=""
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    "-v" | "--version")
+      shift
+      CHART_VERSION="$1"
+      ;;
+    "-c" | "--component")
+      shift
+      COMPONENT="$1"
+      ;;
+    *)
+      usage
+  esac
+  shift
+done
+
+if [ -z "$COMPONENT" ]; then
+  echo "Must specify a component (--component)."
+  usage
+fi
+
+get_past_version () {
+  git show "v$2:./templates/$1.yaml" \
+    | grep ghcr.io/cobrowseio \
+    | grep -Eo ":[0-9]+.[0-9]+.[0-9]+" \
+    | cut -c2-
+}
+
+get_current_version () {
+  cat "./templates/$1.yaml" \
+    | grep ghcr.io/cobrowseio \
+    | grep -Eo ":[0-9]+.[0-9]+.[0-9]+" \
+    | cut -c2-
+}
+
+if [ -z "$CHART_VERSION" ]; then
+  echo "$(get_current_version $COMPONENT)"
+else
+  echo "$(get_past_version $COMPONENT $CHART_VERSION)"
+fi


### PR DESCRIPTION
Example:

The `-v` argument is optional. If unspecified, it will use the version currently found in `Chart.yaml`. So that "happy path" of this would be to run `generate-component-changelog.sh` without any arguments, **before** version bump, while the local working copy has the target versions for each enterprise docker container without any arguments.

```
$ ./scripts/generate-component-changelog.sh -p 1.5.8 -n 2.0.0
Release v2.0.0

The Cobrowse team are happy to announce version v2.0.0 of Cobrowse Enterprise!

## Features
[features]

## Bug Fixes
[fixes]

## Breaking changes
[breaking changes]

## Deployment instructions
Run `helm upgrade`

## Detailed changes

### Cobrowse Enterprise Helm
* fix: include merges if filtering first parent (a6bbe4f)
* chore: add suggestion for prebump/postbump workflow (8bcb416)
* chore: add helm changelogs (25a494d)
* chore: add component changelog script documentation (9c214a5)
* chore: generate changelogs for each component (ee448d7)
* Merge pull request #13 from mrvisser/prometheus-scraping (93de75c)
* Merge pull request #11 from mrvisser/pod-app-label (b32b572)
* Merge pull request #12 from mrvisser/custom-configs (1569579)
* Merge pull request #9 from mrvisser/fix-azure-pathPrefix (ed570ed)
* fix: fix DEBUG helm value for api (2fa4969)
* Merge pull request #8 from mrvisser/local-deployment-squash (3fad028)
* feat: always use pathType=Prefix for Ingress (d7496a2)
* chore(release): 1.5.12 (2670c95)
* build(helm): package helm chart (ca293ea)
* fix(images): update image versions (e9cdfad)
* chore(release): 1.5.11 (e616103)
* build(helm): package helm chart (780251c)
* fix(images): update image versions (0236f0f)
* chore(release): 1.5.10 (ba9ac73)
* build(helm): package helm chart (9739a8b)
* fix(images): update image versions (9dcb0d2)
* chore(release): 1.5.9 (3007e47)
* build(helm): package helm chart (8f62808)
* fix(images): update image versions (531ef3b)

### Cobrowse Enterprise API
* 1.12.1 (d2c64bf)
* update error message (c75e3aa)
* prevent magic link token re-use (ce660e1)
* 1.12.0 (e901375)
* allow GET for devices (3efdc16)
* never add device tokens when device sockets are disabled (e118ec7)
* 1.11.0 (9f54cc1)
* Make sure salesforce JWTs will respect device listing account settings (d87ef33)
* throw error on invalid genesys conversation IDs (214fe01)
* make sure zendesk JWTs respect device listing settings (be7bc80)
* remove old salesforce routes (33c7e20)
* improve error messages (c8e8902)
* update integrations to v2 policies (c4b765f)
* Merge branch 'master' into feature/policy-v2 (8fd68de)
* Merge branch 'master' into feature/policy-v2 (106df8c)
* Merge branch 'master' into feature/policy-v2 (cfeca95)
* use v2 policy for demo (a983c6c)
* log v1 policy usage (3433261)
* only apply default policy restrictions for v2 policies (28d62d3)
* feat: Added v2 policies to support restricting access to resources based on resource IDs (c57daed)

### Cobrowse Enterprise Sockets
No changes.

### Cobrowse Enterprise Proxy
No changes.

### Cobrowse Enterprise Recording
No changes.

### Cobrowse Enterprise Frontend
* 2.9.0 (71824e8)
* run as nginx user (f4746c6)
* Merge pull request #16 from aaronhuggins/alpine (72ff00a)
* dependency updates (7deabc8)
* 2.8.3 (31b70d7)
* typo fix (80ee2a3)
* chore(release): 2.8.2 (2517bd1)
* fix: use X-XSS-Protection 0 as according to latest recommendations (2fed8ba)
* make sure .DS_Store files don't get included in enterprise build (e965c6a)
* remove dynamic env var file from enterprise build (e11364b)
* chore(release): 2.8.1 (e51e103)
* fix: always re-request remote control on tool selection if not already approved (cefb857)
* Merge branch 'feature/remote-control-postmessage' (6ab6823)
* handle token used errors more gracefully (e0b77c4)
* fix: show permission error when agent accesses admin settings (c9e14e5)
* allow toggling banner switch from admin dashboard (635fb5e)
* initialise custom data on session create for device push (919e47c)
* update zendesk app (f3f3352)
* 2.7.3 (5b97304)
* Merge pull request #15 from cobrowseio/snyderj/todomvc-session-code-ui (39efd09)
* 2.7.2 (856c02f)
* update salesforce app to use window.location.origin as API (95e6119)
```

The thought is generate-component-changelog.sh could be run an its output redirected to a file, or in the case of a utility that generates a github release from some content, this could become part of that content. Then the creator of the release can update what they need to before publishing the release.