### PR TITLE
feat: allow docker credentials to be managed externally from helm

### DIFF
--- a/templates/docker-cfg.yaml
+++ b/templates/docker-cfg.yaml
@@ -1,3 +1,4 @@
+{{ if and .Values.imageCredentials .Values.imageCredentials.password -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}


### PR DESCRIPTION
The customer can simply not provide credentials in the values.yml file. If they omit it, the cobrowse-docker-cfg secret will not be created.

The customer can then create and manage it themselves by running something like:

```
kubectl create secret docker-registry cobrowse-docker-cfg \
  --docker-server=ghcr.io \
  --docker-username=cobrowse-enterprise \
  --docker-password="<token provided by cobrowse>"
```