### PR TITLE
Adding override for secrets to be used differently

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cobrowse-enterprise
-version: 1.7.1
+version: 1.7.2
 kubeVersion: ">=1.19.0-0"
 description: Helm Chart for Cobrowse Enterprise
 keywords:

--- a/templates/api-secret.yaml
+++ b/templates/api-secret.yaml
@@ -1,15 +1,18 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Release.Name }}-api-envvars
-  namespace: {{ .Release.Namespace | default "default" }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    stage: {{ .Values.stage | quote }}
-type: Opaque
-data:
-  mongo_url: {{ default "" .Values.mongo.url | b64enc | quote }}
-  redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
+{{- if and .Values.redis .Values.redis.url .Values.mongo .Values.mongo.url }}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ .Release.Name }}-api-envvars
+    namespace: {{ .Release.Namespace | default "default" }}
+    labels:
+      app: {{ template "fullname" . }}
+      chart: {{ template "chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      stage: {{ .Values.stage | quote }}
+  type: Opaque
+  data:
+    mongo_url: {{ default "" .Values.mongo.url | b64enc | quote }}
+    redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
+{{- end }}
+

--- a/templates/docker-cfg.yaml
+++ b/templates/docker-cfg.yaml
@@ -1,16 +1,16 @@
 {{ if and .Values.imageCredentials .Values.imageCredentials.password -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Release.Name }}-docker-cfg
-  namespace: {{ .Release.Namespace | default "default" }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    stage: {{ .Values.stage | quote }}
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: {{ template "imagePullSecret" . }}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ .Release.Name }}-docker-cfg
+    namespace: {{ .Release.Namespace | default "default" }}
+    labels:
+      app: {{ template "fullname" . }}
+      chart: {{ template "chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      stage: {{ .Values.stage | quote }}
+  type: kubernetes.io/dockerconfigjson
+  data:
+    .dockerconfigjson: {{ template "imagePullSecret" . }}
 {{- end }}

--- a/templates/sockets-secret.yaml
+++ b/templates/sockets-secret.yaml
@@ -1,15 +1,17 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Release.Name }}-sockets-envvars
-  namespace: {{ .Release.Namespace | default "default" }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    stage: {{ .Values.stage | quote }}
-type: Opaque
-data:
-  peering_token: {{ randAlphaNum 32 | b64enc | quote }}
-  redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
+{{- if and .Values.redis .Values.redis.url }}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ .Release.Name }}-sockets-envvars
+    namespace: {{ .Release.Namespace | default "default" }}
+    labels:
+      app: {{ template "fullname" . }}
+      chart: {{ template "chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      stage: {{ .Values.stage | quote }}
+  type: Opaque
+  data:
+    peering_token: {{ randAlphaNum 32 | b64enc | quote }}
+    redis_url: {{ default "" .Values.redis.url | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
The current use of the chart mandate that the secrets should be auto-created on installation.
However, this disabled us to use the values.yaml of our custom values inside the Source Control (since it contains sensitive information secrets).

This PR contains custom values to control the usage of the secrets, which will let us create the Secrets manually and differently (for example, Configuration Management and External Secret) on our clusters, and override the default behaviour.