### PR TITLE
fix: quotes are not needed for null in helm values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ ingress:
 storage:
   # * class: "class-name" - Supports dynamic provisioning when you have a
   #                         specific storage class available, such as "nfs"
-  # * class: "null"       - Supports static provisioning. You should
+  # * class: null         - Supports static provisioning. You should
   #                         configure your own statically-provisioned PVC
   #                         resource with name "cobrowse-sockets-pvc", and
   #                         accompanying PV resource


### PR DESCRIPTION
Cleaning up my working copies and found this little nugget. The quotes are required for terraform helm_release module, but not for yaml-based values.yaml