### PR TITLE
feat: configurable service image repo

### DIFF
--- a/scripts/generate-component-changelog.sh
+++ b/scripts/generate-component-changelog.sh
@@ -18,14 +18,12 @@
 #
 # Arguments:
 #
-# `--next-version`: The next version of the helm chart being released
 # `--prev-version`: The source version from which to get component version
 #                   references. If unspecified, will use the version specified
 #                   in the working copy of `Chart.yaml`. This is usually what
 #                   you want.
 ##
 
-HELM_NEXT_VERSION=""
 HELM_PREV_VERSION=$(./scripts/get-chart-version.sh)
 
 usage() { echo "Usage: $0 [--prev-version <helm chart version (default: $HELM_PREV_VERSION)>]" 1>&2; exit 1; }

--- a/scripts/get-component-version.sh
+++ b/scripts/get-component-version.sh
@@ -49,7 +49,7 @@ fi
 
 get_past_version () {
   git show "v$2:./templates/$1.yaml" \
-    | grep ghcr.io/cobrowseio \
+    | grep "image:" \
     | grep -Eo ":[0-9]+.[0-9]+.[0-9]+" \
     | head -n 1 \
     | cut -c2-
@@ -57,7 +57,7 @@ get_past_version () {
 
 get_current_version () {
   cat "./templates/$1.yaml" \
-    | grep ghcr.io/cobrowseio \
+    | grep "image:" \
     | grep -Eo ":[0-9]+.[0-9]+.[0-9]+" \
     | head -n 1 \
     | cut -c2-

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-api-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default "ghcr.io/cobrowseio/cobrowse-api-enterprise:1.22.14" }}
+        image: {{ (.Values.api.image).ref | default (printf "%s/cobrowse-api-enterprise:1.22.14" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.api.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-frontend-custom-envvars
             optional: true
-        image: {{ (.Values.frontend.image).ref | default "ghcr.io/cobrowseio/cobrowse-frontend-enterprise:2.19.11" }}
+        image: {{ (.Values.frontend.image).ref | default (printf "%s/cobrowse-frontend-enterprise:2.19.11" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.frontend.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-proxy-custom-envvars
             optional: true
-        image: {{ (.Values.proxy.image).ref | default "ghcr.io/cobrowseio/cobrowse-proxy-enterprise:1.3.17" }}
+        image: {{ (.Values.proxy.image).ref | default (printf "%s/cobrowse-proxy-enterprise:1.3.17" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.proxy.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-recording-custom-envvars
             optional: true
-        image: {{ (.Values.recording.image).ref | default "ghcr.io/cobrowseio/cobrowse-recording-enterprise:1.7.4" }}
+        image: {{ (.Values.recording.image).ref | default (printf "%s/cobrowse-recording-enterprise:1.7.4" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.recording.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3
@@ -98,7 +98,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-chromium-custom-envvars
             optional: true
-        image: {{ (.Values.chromium.image).ref | default "ghcr.io/cobrowseio/cobrowse-chromium-enterprise:1.7.4" }}
+        image: {{ (.Values.chromium.image).ref | default (printf "%s/cobrowse-chromium-enterprise:1.7.4" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.chromium.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-sockets-custom-envvars
             optional: true
-        image: {{ (.Values.sockets.image).ref | default "ghcr.io/cobrowseio/cobrowse-api-sockets-enterprise:1.3.12" }}
+        image: {{ (.Values.sockets.image).ref | default (printf "%s/cobrowse-api-sockets-enterprise:1.3.12" .Values.image.repo) }}
         imagePullPolicy: {{ (.Values.sockets.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,10 @@ storage:
   class: "nfs"
   size: "50Gi"
 
+# Default cobrowse service image configuration
+image:
+  repo: "ghcr.io/cobrowseio"
+
 # API configurations
 api:
   replicas: 1


### PR DESCRIPTION
It doesn't look like any updates are needed for the version rewriting script. Relevant bits:

```bash
sed -i '' "s/cobrowse-frontend-enterprise:[0-9.]*/cobrowse-frontend-enterprise:${FRONTEND_VERSION}/" "$HELM_CHART/frontend-deployment.yaml"
sed -i '' "s/cobrowse-api-enterprise:[0-9.]*/cobrowse-api-enterprise:${API_VERSION}/" "$HELM_CHART/api-deployment.yaml"
sed -i '' "s/cobrowse-api-sockets-enterprise:[0-9.]*/cobrowse-api-sockets-enterprise:${SOCKETS_VERSION}/" "$HELM_CHART/sockets-statefulset.yaml"
sed -i '' "s/cobrowse-proxy-enterprise:[0-9.]*/cobrowse-proxy-enterprise:${PROXY_VERSION}/" "$HELM_CHART/proxy-deployment.yaml"
sed -i '' "s/cobrowse-recording-enterprise:[0-9.]*/cobrowse-recording-enterprise:${RECORDING_VERSION}/" "$HELM_CHART/recording-deployment.yaml"
sed -i '' "s/cobrowse-chromium-enterprise:[0-9.]*/cobrowse-chromium-enterprise:${RECORDING_VERSION}/" "$HELM_CHART/recording-deployment.yaml"
```

They're all hedged on the container name, not the repo name.