### PR TITLE
feat: support use of local images through image.repo

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,3 +37,10 @@ Create the default SecurityContext for all service components
 {{- define "defaultSecurityContext" }}
 {{- dict "allowPrivilegeEscalation" false "privileged" false "readOnlyRootFilesystem" true | toYaml }}
 {{- end }}
+
+{{/*
+Create the default image reference for the specified image and version
+*/}}
+{{- define "image" }}
+{{- printf "%s%s%s" (ternary .repo "" (ne .repo "")) (ternary "/" "" (ne .repo "")) .image }}
+{{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-api-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (printf "%s/cobrowse-api-enterprise:1.25.4" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-enterprise:1.25.4" )) }}
         imagePullPolicy: {{ (.Values.api.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-frontend-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-frontend-enterprise:2.24.6" )) }}
+        image: {{ (.Values.frontend.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-frontend-enterprise:2.24.6" )) }}
         imagePullPolicy: {{ (.Values.frontend.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-frontend-custom-envvars
             optional: true
-        image: {{ (.Values.frontend.image).ref | default (printf "%s/cobrowse-frontend-enterprise:2.24.6" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-frontend-enterprise:2.24.6" )) }}
         imagePullPolicy: {{ (.Values.frontend.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-proxy-custom-envvars
             optional: true
-        image: {{ (.Values.proxy.image).ref | default (printf "%s/cobrowse-proxy-enterprise:1.3.17" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-proxy-enterprise:1.3.17" )) }}
         imagePullPolicy: {{ (.Values.proxy.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-proxy-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-proxy-enterprise:1.3.17" )) }}
+        image: {{ (.Values.proxy.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-proxy-enterprise:1.3.17" )) }}
         imagePullPolicy: {{ (.Values.proxy.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-recording-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-recording-enterprise:1.7.4" )) }}
+        image: {{ (.Values.recording.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-recording-enterprise:1.7.4" )) }}
         imagePullPolicy: {{ (.Values.recording.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3
@@ -98,7 +98,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-chromium-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-chromium-enterprise:1.7.4" )) }}
+        image: {{ (.Values.chromium.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-chromium-enterprise:1.7.4" )) }}
         imagePullPolicy: {{ (.Values.chromium.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-recording-custom-envvars
             optional: true
-        image: {{ (.Values.recording.image).ref | default (printf "%s/cobrowse-recording-enterprise:1.7.4" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-recording-enterprise:1.7.4" )) }}
         imagePullPolicy: {{ (.Values.recording.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3
@@ -98,7 +98,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-chromium-custom-envvars
             optional: true
-        image: {{ (.Values.chromium.image).ref | default (printf "%s/cobrowse-chromium-enterprise:1.7.4" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-chromium-enterprise:1.7.4" )) }}
         imagePullPolicy: {{ (.Values.chromium.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-sockets-custom-envvars
             optional: true
-        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-sockets-enterprise:1.3.12" )) }}
+        image: {{ (.Values.sockets.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-sockets-enterprise:1.3.12" )) }}
         imagePullPolicy: {{ (.Values.sockets.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-sockets-custom-envvars
             optional: true
-        image: {{ (.Values.sockets.image).ref | default (printf "%s/cobrowse-api-sockets-enterprise:1.3.12" .Values.image.repo) }}
+        image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-sockets-enterprise:1.3.12" )) }}
         imagePullPolicy: {{ (.Values.sockets.image).pullPolicy }}
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
Air gapped installs include the possibility of running from images that are local to the nodes via docker load/save. Support referencing local images using the `image.repo` value (empty string) so we don't have to expose public-facing documentation how to override full images and versions.