### PR TITLE
fix: allow override proxy and recording replicas to 0

### DIFF
--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
 spec:
-  replicas: {{ .Values.proxy.replicas | default "1" }}
+  replicas: {{ .Values.proxy.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
 spec:
-  replicas: {{ .Values.recording.replicas | default "1" }}
+  replicas: {{ .Values.recording.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Without this, the `| default` pipe seems to kick in and default to `1` if we attempt to override value to `0`.

We already have `1` set in the bundled `values.yml` so this should be fine I think.

