### PR TITLE
feat(all): add capability to disable securityContext

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -80,9 +80,11 @@ spec:
           requests:
             cpu: {{ .Values.api.cpu | default "256m" }}
             memory: {{ .Values.api.memory | default "256Mi" }}
+        {{- if .Values.api.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.api.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.api.runAs).user | default "1000" }}
+        {{- end }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-docker-cfg

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -76,10 +76,12 @@ spec:
           requests:
             cpu: {{ .Values.frontend.cpu | default "256m"}}
             memory: {{ .Values.frontend.memory | default "256Mi"}}
+        {{- if .Values.frontend.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.frontend.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.frontend.runAs).user | default "1000" }}
+        {{- end }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-docker-cfg
       volumes:

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -80,9 +80,11 @@ spec:
           requests:
             cpu: {{ .Values.proxy.cpu | default "256m"}}
             memory: {{ .Values.proxy.memory | default "256Mi"}}
+        {{- if .Values.proxy.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.proxy.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.proxy.runAs).user | default "1000" }}
+        {{- end }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-docker-cfg

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -87,10 +87,12 @@ spec:
           requests:
             cpu: {{ .Values.recording.cpu | default "256m"}}
             memory: {{ .Values.recording.memory | default "256Mi"}}
+        {{- if .Values.recording.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.recording.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.recording.runAs).user | default "1000" }}
+        {{- end }}
       # Chromium container
       - envFrom:
         - configMapRef:
@@ -135,10 +137,12 @@ spec:
           requests:
             cpu: {{ .Values.chromium.cpu | default "700m"}}
             memory: {{ .Values.chromium.memory | default "1G"}}
+        {{- if .Values.chromium.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.chromium.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.chromium.runAs).user | default "1000" }}
+        {{- end }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-docker-cfg
       volumes:

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -78,10 +78,12 @@ spec:
           requests:
             cpu: {{ .Values.sockets.cpu | default "256m" }}
             memory: {{ .Values.sockets.memory | default "256Mi" }}
+        {{- if .Values.sockets.containerSecurityContext.enabled }}
         securityContext:
           {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.sockets.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.sockets.runAs).user | default "1000" }}
+        {{- end }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-docker-cfg
       volumes:

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,8 @@ api:
 
   service:
     type: ""
+  containerSecurityContext:
+    enabled: true
 
 
 # Frontend configurations
@@ -57,6 +59,8 @@ frontend:
 
   service:
     type: ""
+  containerSecurityContext:
+    enabled: true
 
 
 # Proxy configurations
@@ -68,6 +72,8 @@ proxy:
 
   service:
     type: ""
+  containerSecurityContext:
+    enabled: true
 
 
 # Recording configurations
@@ -83,11 +89,15 @@ recording:
   storage: {
     # persistentVolumeClaimName: "cobrowse-sockets-pvc"
   }
+  containerSecurityContext:
+    enabled: true
 
 # Chromium configurations
 chromium:
   cpu: ""
   memory: ""
+  containerSecurityContext:
+    enabled: true
 
 
 # Sockets configurations
@@ -103,3 +113,5 @@ sockets:
   storage: {
     # persistentVolumeClaimName: "cobrowse-sockets-pvc"
   }
+  containerSecurityContext:
+    enabled: true


### PR DESCRIPTION
Hello,

In our deployments, we would like to be able to disable securityContext definitions.

Would it be possible to add this option? 