### PR TITLE
feat: adds anti affinity on hostname to sockets

### DIFF
--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -29,6 +29,18 @@ spec:
         component: sockets
         stage: {{ .Values.stage | quote }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - sockets
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - envFrom:
         - configMapRef:


### PR DESCRIPTION
This adds the anti-affinity rule only to sockets were the impact of pods going down would be higher. 

Tested that the deployment is done successfully but didn't do a functional test.