### PR TITLE
Feat/disable default backend

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
   name: api-ingress
   namespace: {{ .Release.Namespace | default "default" }}
 spec:
+{{- if not .Values.ingress.disableDefaultBackend }}
   defaultBackend:
     service:
       name: {{ .Release.Name }}-frontend-svc
@@ -29,6 +30,7 @@ spec:
   - hosts:
     - {{ .Values.domain }}
   - secretName: {{ ((.Values.ingress).tls).secretName | quote }}
+{{- end }}
 {{- end }}
   rules:
   - http:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -25,12 +25,12 @@ spec:
       name: {{ .Release.Name }}-frontend-svc
       port:
         number: 8080
+{{- end }}
 {{- if ((.Values.ingress).tls).secretName }}
   tls:
   - hosts:
     - {{ .Values.domain }}
   - secretName: {{ ((.Values.ingress).tls).secretName | quote }}
-{{- end }}
 {{- end }}
   rules:
   - http:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -62,4 +62,6 @@ spec:
               number: 8080
         path: /
         pathType: Prefix
+  {{- if ((.Values.ingress).tls).secretName }}
     host: {{ .Values.domain }}
+  {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
 {{- if eq .Values.ingress.class "gce" }}
-    networking.gke.io/managed-certificates: "cobrowse-api-ssl"
     networking.gke.io/v1beta1.FrontendConfig: "api-frontend-config"
 {{- end }}
   {{- range $key, $value := .Values.ingress.annotations }}
@@ -19,13 +18,6 @@ metadata:
   name: api-ingress
   namespace: {{ .Release.Namespace | default "default" }}
 spec:
-{{- if not .Values.ingress.disableDefaultBackend }}
-  defaultBackend:
-    service:
-      name: {{ .Release.Name }}-frontend-svc
-      port:
-        number: 8080
-{{- end }}
 {{- if ((.Values.ingress).tls).secretName }}
   tls:
   - hosts:
@@ -63,6 +55,11 @@ spec:
               number: 8080
         path: /sockets
         pathType: Prefix
-  {{- if ((.Values.ingress).tls).secretName }}
+      - backend:
+          service:
+            name: {{ .Release.Name }}-frontend-svc
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
     host: {{ .Values.domain }}
-  {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -321,16 +321,6 @@
                     ],
                     "required": [],
                     "additionalProperties": true
-                },
-                "disableDefaultBackend": {
-                    "$id": "#/properties/ingress/properties/disableDefaultBackend",
-                    "type": "boolean",
-                    "title": "If defaultBackend should be disabled",
-                    "description": "Disables the Ingress defaultBackend..",
-                    "default": "",
-                    "examples": [
-                        true, false
-                    ]
                 }
             },
             "additionalProperties": true

--- a/values.schema.json
+++ b/values.schema.json
@@ -321,6 +321,16 @@
                     ],
                     "required": [],
                     "additionalProperties": true
+                },
+                "disableDefaultBackend": {
+                    "$id": "#/properties/ingress/properties/disableDefaultBackend",
+                    "type": "boolean",
+                    "title": "If defaultBackend should be disabled",
+                    "description": "Disables the Ingress defaultBackend..",
+                    "default": "",
+                    "examples": [
+                        true, false
+                    ]
                 }
             },
             "additionalProperties": true


### PR DESCRIPTION
Disabling the defaultBackend in the Cobrowse ingress is required in K8s cluster where other services are installed.

The new setting is named in the negative to keep the common case and the default, the case where  the Cobrowse ingress in the defaultBackend.