### PR TITLE
fix: only include imagePullPolicy when present

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -52,7 +52,9 @@ spec:
             name: {{ .Release.Name }}-api-custom-envvars
             optional: true
         image: {{ (.Values.api.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-enterprise:1.67.7" )) }}
+        {{- if (.Values.api.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.api.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -49,7 +49,9 @@ spec:
             name: {{ .Release.Name }}-frontend-custom-envvars
             optional: true
         image: {{ (.Values.frontend.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-frontend-enterprise:3.13.2" )) }}
+        {{- if (.Values.frontend.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.frontend.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 30

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -52,7 +52,9 @@ spec:
             name: {{ .Release.Name }}-proxy-custom-envvars
             optional: true
         image: {{ (.Values.proxy.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-proxy-enterprise:1.22.1" )) }}
+        {{- if (.Values.proxy.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.proxy.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -54,7 +54,9 @@ spec:
             name: {{ .Release.Name }}-recording-custom-envvars
             optional: true
         image: {{ (.Values.recording.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-recording-enterprise:1.12.2" )) }}
+        {{- if (.Values.recording.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.recording.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -106,7 +108,9 @@ spec:
             name: {{ .Release.Name }}-chromium-custom-envvars
             optional: true
         image: {{ (.Values.chromium.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-chromium-enterprise:1.12.2" )) }}
+        {{- if (.Values.chromium.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.chromium.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -59,7 +59,9 @@ spec:
             name: {{ .Release.Name }}-sockets-custom-envvars
             optional: true
         image: {{ (.Values.sockets.image).ref | default (include "image" (dict "repo" .Values.image.repo "image" "cobrowse-api-sockets-enterprise:1.13.3" )) }}
+        {{- if (.Values.sockets.image).pullPolicy }}
         imagePullPolicy: {{ (.Values.sockets.image).pullPolicy }}
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Only sets imagePullPolicy when defined. This avoids an whitespace issue for Google when the value is not present.