### PR TITLE
fix: add extra configurations

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -39,6 +39,9 @@ spec:
         component: api
         stage: {{ .Values.stage | quote }}
     spec:
+    {{- if .Values.customTemplateSpec }}
+      {{ .Values.customTemplateSpec }}
+    {{- end }}
       containers:
       - envFrom:
         - configMapRef:
@@ -82,14 +85,13 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: {{ .Values.api.cpu | default "256m" }}
-            memory: {{ .Values.api.memory | default "256Mi" }}
+            cpu: {{ coalesce .Values.api.limits.cpu .Values.api.cpu "256m" }}
+            memory: {{ coalesce .Values.api.limits.memory .Values.api.memory "256Mi" }}
           requests:
             cpu: {{ .Values.api.cpu | default "256m" }}
             memory: {{ .Values.api.memory | default "256Mi" }}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.api.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.api.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
+  {{- range $key, $value := .Values.api.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   replicas: {{ .Values.api.replicas | default "1" }}
   strategy:
@@ -39,8 +42,8 @@ spec:
         component: api
         stage: {{ .Values.stage | quote }}
     spec:
-    {{- if .Values.customTemplateSpec }}
-      {{ .Values.customTemplateSpec }}
+    {{- if .Values.api.nodeSelector}}
+      nodeSelector:{{ toYaml .Values.api.nodeSelector | nindent 8 }}
     {{- end }}
       containers:
       - envFrom:
@@ -91,7 +94,7 @@ spec:
             cpu: {{ .Values.api.cpu | default "256m" }}
             memory: {{ .Values.api.memory | default "256Mi" }}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.api.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.api.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
+  {{- range $key, $value := .Values.frontend.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   replicas: {{ .Values.frontend.replicas | default "1" }}
   strategy:
@@ -36,8 +39,8 @@ spec:
         component: frontend
         stage: {{ .Values.stage | quote }}
     spec:
-    {{- if .Values.customTemplateSpec }}
-      {{ .Values.customTemplateSpec }}
+    {{- if .Values.frontend.nodeSelector}}
+      nodeSelector:{{ toYaml .Values.frontend.nodeSelector | nindent 8 }}
     {{- end }}
       containers:
       - envFrom:
@@ -87,7 +90,7 @@ spec:
             cpu: {{ .Values.frontend.cpu | default "256m"}}
             memory: {{ .Values.frontend.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.frontend.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.frontend.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         component: frontend
         stage: {{ .Values.stage | quote }}
     spec:
+    {{- if .Values.customTemplateSpec }}
+      {{ .Values.customTemplateSpec }}
+    {{- end }}
       containers:
       - envFrom:
         - configMapRef:
@@ -78,14 +81,13 @@ spec:
           name: tmp
         resources:
           limits:
-            cpu: {{ .Values.frontend.cpu | default "256m"}}
-            memory: {{ .Values.frontend.memory | default "256Mi"}}
+            cpu: {{ coalesce .Values.frontend.limits.cpu .Values.frontend.cpu "256m"}}
+            memory: {{ coalesce .Values.frontend.limits.memory .Values.frontend.memory "256Mi"}}
           requests:
             cpu: {{ .Values.frontend.cpu | default "256m"}}
             memory: {{ .Values.frontend.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.frontend.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.frontend.runAs).user | default "1000" }}
         {{- end }}
@@ -95,5 +97,5 @@ spec:
       - name: tmp
         emptyDir:
           medium: Memory
-      serviceAccountName: {{ .Values.serviceAccountName | default "" }}    
+      serviceAccountName: {{ .Values.serviceAccountName | default "" }}
       automountServiceAccountToken: false

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,13 +8,13 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     stage: {{ .Values.stage | quote }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
-{{- if eq .Values.ingress.class "gce" }}
-    networking.gke.io/v1beta1.FrontendConfig: "api-frontend-config"
-{{- end }}
   {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{- if eq .Values.ingress.class "gce" }}
+    networking.gke.io/v1beta1.FrontendConfig: "api-frontend-config"
+  {{- end }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
   name: api-ingress
   namespace: {{ .Release.Namespace | default "default" }}
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,13 +8,13 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     stage: {{ .Values.stage | quote }}
   annotations:
-  {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
   {{- if eq .Values.ingress.class "gce" }}
     networking.gke.io/v1beta1.FrontendConfig: "api-frontend-config"
   {{- end }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   name: api-ingress
   namespace: {{ .Release.Namespace | default "default" }}
 spec:

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -39,6 +39,9 @@ spec:
         component: proxy
         stage: {{ .Values.stage | quote }}
     spec:
+    {{- if .Values.customTemplateSpec }}
+      {{ .Values.customTemplateSpec }}
+    {{- end }}
       containers:
       - envFrom:
         - configMapRef:
@@ -82,14 +85,13 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: {{ .Values.proxy.cpu | default "256m"}}
-            memory: {{ .Values.proxy.memory | default "256Mi"}}
+            cpu: {{ coalesce .Values.proxy.limits.cpu .Values.proxy.cpu "256m"}}
+            memory: {{ coalesce .Values.proxy.limits.memory .Values.proxy.memory "256Mi"}}
           requests:
             cpu: {{ .Values.proxy.cpu | default "256m"}}
             memory: {{ .Values.proxy.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.proxy.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.proxy.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
+  {{- range $key, $value := .Values.proxy.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   replicas: {{ .Values.proxy.replicas }}
   strategy:
@@ -39,8 +42,8 @@ spec:
         component: proxy
         stage: {{ .Values.stage | quote }}
     spec:
-    {{- if .Values.customTemplateSpec }}
-      {{ .Values.customTemplateSpec }}
+    {{- if .Values.frontend.nodeSelector}}
+      nodeSelector:{{ toYaml .Values.frontend.nodeSelector | nindent 8 }}
     {{- end }}
       containers:
       - envFrom:
@@ -91,7 +94,7 @@ spec:
             cpu: {{ .Values.proxy.cpu | default "256m"}}
             memory: {{ .Values.proxy.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.proxy.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.proxy.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         component: recording
         stage: {{ .Values.stage | quote }}
     spec:
+    {{- if .Values.customTemplateSpec }}
+      {{ .Values.customTemplateSpec }}
+    {{- end }}
       containers:
       # Recording container
       - envFrom:
@@ -89,14 +92,13 @@ spec:
           name: tmp
         resources:
           limits:
-            cpu: {{ .Values.recording.cpu | default "256m"}}
-            memory: {{ .Values.recording.memory | default "256Mi"}}
+            cpu: {{ coalesce .Values.recording.limits.cpu .Values.recording.cpu "256m"}}
+            memory: {{ coalesce .Values.recording.limits.memory .Values.recording.memory "256Mi"}}
           requests:
             cpu: {{ .Values.recording.cpu | default "256m"}}
             memory: {{ .Values.recording.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.recording.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.recording.runAs).user | default "1000" }}
         {{- end }}
@@ -141,14 +143,13 @@ spec:
           name: tmp
         resources:
           limits:
-            cpu: {{ .Values.chromium.cpu | default "700m"}}
-            memory: {{ .Values.chromium.memory | default "1G"}}
+            cpu: {{ coalesce .Values.chromium.limits.cpu .Values.chromium.cpu "700m"}}
+            memory: {{ coalesce .Values.chromium.limits.memory .Values.chromium.memory "1G"}}
           requests:
             cpu: {{ .Values.chromium.cpu | default "700m"}}
             memory: {{ .Values.chromium.memory | default "1G"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.chromium.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.chromium.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/recording-deployment.yaml
+++ b/templates/recording-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
+  {{- range $key, $value := .Values.recording.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   replicas: {{ .Values.recording.replicas }}
   strategy:
@@ -40,8 +43,8 @@ spec:
         component: recording
         stage: {{ .Values.stage | quote }}
     spec:
-    {{- if .Values.customTemplateSpec }}
-      {{ .Values.customTemplateSpec }}
+    {{- if .Values.recording.nodeSelector}}
+      nodeSelector:{{ toYaml .Values.recording.nodeSelector | nindent 8 }}
     {{- end }}
       containers:
       # Recording container
@@ -98,7 +101,7 @@ spec:
             cpu: {{ .Values.recording.cpu | default "256m"}}
             memory: {{ .Values.recording.memory | default "256Mi"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.recording.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.recording.runAs).user | default "1000" }}
         {{- end }}
@@ -149,7 +152,7 @@ spec:
             cpu: {{ .Values.chromium.cpu | default "700m"}}
             memory: {{ .Values.chromium.memory | default "1G"}}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.chromium.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.chromium.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/sockets-secret.yaml
+++ b/templates/sockets-secret.yaml
@@ -11,5 +11,9 @@ metadata:
     stage: {{ .Values.stage | quote }}
 type: Opaque
 data:
+  {{- if .Values.sockets.peeringToken }}
+  peering_token: {{ .Values.sockets.peeringToken | quote }}
+  {{- else }}
   peering_token: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
   redis_url: {{ default "" .Values.redis.url | b64enc | quote }}

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     stage: {{ .Values.stage | quote }}
+  {{- range $key, $value := .Values.sockets.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-sockets-headless
   replicas: {{ .Values.sockets.replicas | default "1" }}
@@ -34,8 +37,8 @@ spec:
         component: sockets
         stage: {{ .Values.stage | quote }}
     spec:
-    {{- if .Values.customTemplateSpec }}
-      {{ .Values.customTemplateSpec }}
+    {{- if .Values.sockets.nodeSelector}}
+      nodeSelector:{{ toYaml .Values.sockets.nodeSelector | nindent 8 }}
     {{- end }}
       affinity:
         podAntiAffinity:
@@ -101,7 +104,7 @@ spec:
             cpu: {{ .Values.sockets.cpu | default "256m" }}
             memory: {{ .Values.sockets.memory | default "256Mi" }}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext:{{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.sockets.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.sockets.runAs).user | default "1000" }}
         {{- end }}

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -34,6 +34,9 @@ spec:
         component: sockets
         stage: {{ .Values.stage | quote }}
     spec:
+    {{- if .Values.customTemplateSpec }}
+      {{ .Values.customTemplateSpec }}
+    {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -92,14 +95,13 @@ spec:
           name: data-traces
         resources:
           limits:
-            cpu: {{ .Values.sockets.cpu | default "256m" }}
-            memory: {{ .Values.sockets.memory | default "256Mi" }}
+            cpu: {{ coalesce .Values.sockets.limits.cpu .Values.sockets.cpu "256m" }}
+            memory: {{ coalesce .Values.sockets.limits.memory .Values.sockets.memory "256Mi" }}
           requests:
             cpu: {{ .Values.sockets.cpu | default "256m" }}
             memory: {{ .Values.sockets.memory | default "256Mi" }}
         {{- if .Values.containerSecurityContext.enabled }}
-        securityContext:
-          {{ include "defaultSecurityContext" . | nindent 10 }}
+        securityContext: {{ include "defaultSecurityContext" . | nindent 10 }}
           runAsGroup: {{ (.Values.sockets.runAs).group | default "1000" }}
           runAsUser: {{ (.Values.sockets.runAs).user | default "1000" }}
         {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -44,7 +44,10 @@
                     "annotations": [ 
                         {"key": "value" }
                     ]
-                }
+                },
+                "labels": [
+                    { "key": "value" }
+                ]
             },
             "frontend": {
                 "replicas": 1,
@@ -57,7 +60,10 @@
                     "annotations": [ 
                         {"key": "value" }
                     ]
-                }
+                },
+                "labels": [
+                    { "key": "value" }
+                ]
             },
             "proxy": {
                 "replicas": 1,
@@ -71,7 +77,10 @@
                     "annotations": [ 
                         {"key": "value" }
                     ]
-                }
+                },
+                "labels": [
+                    { "key": "value" }
+                ]
             },
             "recording": {
                 "replicas": 1,
@@ -85,7 +94,10 @@
                     "annotations": [ 
                         {"key": "value" }
                     ]
-                }
+                },
+                "labels": [
+                    { "key": "value" }
+                ]
             },
             "sockets": {
                 "replicas": 1,
@@ -99,7 +111,10 @@
                     "annotations": [ 
                         {"key": "value" }
                     ]
-                }
+                },
+                "labels": [
+                    { "key": "value" }
+                ]
             }
         }
     ],
@@ -501,6 +516,18 @@
                     },
                     "additionalProperties": true
                 },
+                "labels": {
+                    "$id": "#/properties/api/properties/labels",
+                    "type": "object",
+                    "title": "The API labels",
+                    "description": "An array of labels",
+                    "default": {},
+                    "examples": [
+                        { "key" : "value" }
+                    ],
+                    "required": [],
+                    "additionalProperties": true
+                },
                 "pod": {
                     "$id": "#/properties/api/properties/pod",
                     "type": "object",
@@ -648,6 +675,18 @@
                             ]
                         }
                     },
+                    "additionalProperties": true
+                },
+                "labels": {
+                    "$id": "#/properties/frontend/properties/labels",
+                    "type": "object",
+                    "title": "The Frontend labels.",
+                    "description": "An array of labels",
+                    "default": {},
+                    "examples": [
+                        { "key" : "value" }
+                    ],
+                    "required": [],
                     "additionalProperties": true
                 },
                 "pod": {
@@ -809,6 +848,18 @@
                             ]
                         }
                     },
+                    "additionalProperties": true
+                },
+                "labels": {
+                    "$id": "#/properties/proxy/properties/labels",
+                    "type": "object",
+                    "title": "The Proxy labels",
+                    "description": "An array of labels",
+                    "default": {},
+                    "examples": [
+                        { "key" : "value" }
+                    ],
+                    "required": [],
                     "additionalProperties": true
                 },
                 "pod": {
@@ -998,6 +1049,18 @@
                     },
                     "additionalProperties": true
                 },
+                "labels": {
+                    "$id": "#/properties/recording/properties/labels",
+                    "type": "object",
+                    "title": "The Recording labels",
+                    "description": "An array of labels",
+                    "default": {},
+                    "examples": [
+                        { "key" : "value" }
+                    ],
+                    "required": [],
+                    "additionalProperties": true
+                },
                 "pod": {
                     "$id": "#/properties/recording/properties/pod",
                     "type": "object",
@@ -1185,6 +1248,18 @@
                     },
                     "additionalProperties": true
                 },
+                "labels": {
+                    "$id": "#/properties/sockets/properties/labels",
+                    "type": "object",
+                    "title": "The Sockets labels",
+                    "description": "An array of labels",
+                    "default": {},
+                    "examples": [
+                        { "key" : "value" }
+                    ],
+                    "required": [],
+                    "additionalProperties": true
+                },
                 "pod": {
                     "$id": "#/properties/sockets/properties/pod",
                     "type": "object",
@@ -1212,6 +1287,16 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "peeringToken": {
+                    "$id": "#/properties/sockets/properties/peeringToken",
+                    "type": "string",
+                    "title": "The sockets peering token.",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": "",
+                    "examples": [
+                        ""
+                    ]
                 }
             },
             "additionalProperties": true

--- a/values.schema.json
+++ b/values.schema.json
@@ -426,6 +426,43 @@
                         ""
                     ]
                 },
+                "limits": {
+                    "$id": "#/properties/api/properties/limits",
+                    "type": "object",
+                    "title": "The limits schema",
+                    "description": "CPU and Memory limits.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "cpu": "",
+                            "memory": ""
+                        }
+                    ],
+                    "required": [],
+                    "properties": {
+                        "cpu": {
+                            "$id": "#/properties/api/properties/limits/properties/cpu",
+                            "type": "string",
+                            "title": "The cpu limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "memory": {
+                            "$id": "#/properties/api/properties/limits/properties/memory",
+                            "type": "string",
+                            "title": "The memory limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                },
                 "debug": {
                     "$id": "#/properties/api/properties/debug",
                     "type": "string",
@@ -548,6 +585,43 @@
                         ""
                     ]
                 },
+                "limits": {
+                    "$id": "#/properties/api/properties/limits",
+                    "type": "object",
+                    "title": "The limits schema",
+                    "description": "CPU and Memory limits.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "cpu": "",
+                            "memory": ""
+                        }
+                    ],
+                    "required": [],
+                    "properties": {
+                        "cpu": {
+                            "$id": "#/properties/api/properties/limits/properties/cpu",
+                            "type": "string",
+                            "title": "The cpu limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "memory": {
+                            "$id": "#/properties/api/properties/limits/properties/memory",
+                            "type": "string",
+                            "title": "The memory limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                },
                 "service": {
                     "$id": "#/properties/frontend/properties/service",
                     "type": "object",
@@ -661,6 +735,43 @@
                     "examples": [
                         ""
                     ]
+                },
+                "limits": {
+                    "$id": "#/properties/api/properties/limits",
+                    "type": "object",
+                    "title": "The limits schema",
+                    "description": "CPU and Memory limits.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "cpu": "",
+                            "memory": ""
+                        }
+                    ],
+                    "required": [],
+                    "properties": {
+                        "cpu": {
+                            "$id": "#/properties/api/properties/limits/properties/cpu",
+                            "type": "string",
+                            "title": "The cpu limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "memory": {
+                            "$id": "#/properties/api/properties/limits/properties/memory",
+                            "type": "string",
+                            "title": "The memory limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
                 },
                 "debug": {
                     "$id": "#/properties/proxy/properties/debug",
@@ -785,6 +896,43 @@
                     "examples": [
                         ""
                     ]
+                },
+                "limits": {
+                    "$id": "#/properties/recording/properties/limits",
+                    "type": "object",
+                    "title": "The limits schema",
+                    "description": "CPU and Memory limits.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "cpu": "",
+                            "memory": ""
+                        }
+                    ],
+                    "required": [],
+                    "properties": {
+                        "cpu": {
+                            "$id": "#/properties/recording/properties/limits/properties/cpu",
+                            "type": "string",
+                            "title": "The cpu limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "memory": {
+                            "$id": "#/properties/recording/properties/limits/properties/memory",
+                            "type": "string",
+                            "title": "The memory limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
                 },
                 "debug": {
                     "$id": "#/properties/recording/properties/debug",
@@ -935,6 +1083,43 @@
                     "examples": [
                         ""
                     ]
+                },
+                "limits": {
+                    "$id": "#/properties/sockets/properties/limits",
+                    "type": "object",
+                    "title": "The limits schema",
+                    "description": "CPU and Memory limits.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "cpu": "",
+                            "memory": ""
+                        }
+                    ],
+                    "required": [],
+                    "properties": {
+                        "cpu": {
+                            "$id": "#/properties/sockets/properties/limits/properties/cpu",
+                            "type": "string",
+                            "title": "The cpu limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "memory": {
+                            "$id": "#/properties/sockets/properties/limits/properties/memory",
+                            "type": "string",
+                            "title": "The memory limit schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
                 },
                 "debug": {
                     "$id": "#/properties/sockets/properties/debug",

--- a/values.yaml
+++ b/values.yaml
@@ -42,9 +42,14 @@ image:
 
 # API configurations
 api:
+  image:
+    ref: ghcr.io/cobrowseio/cobrowse-api-enterprise:1.73.0 
   replicas: 1
   cpu: ""
   memory: ""
+  limits:
+    cpu: ""
+    memory: "" 
   debug: ""
 
   service:
@@ -56,6 +61,9 @@ frontend:
   replicas: 1
   cpu: ""
   memory: ""
+  limits:
+    cpu: ""
+    memory: "" 
 
   service:
     type: ""
@@ -66,7 +74,11 @@ proxy:
   replicas: 1
   cpu: ""
   memory: ""
+  limits:
+    cpu: ""
+    memory: "" 
   debug: ""
+  
 
   service:
     type: ""
@@ -77,6 +89,9 @@ recording:
   replicas: 1
   cpu: ""
   memory: ""
+  limits:
+    cpu: ""
+    memory: "" 
   debug: ""
 
   service:
@@ -90,13 +105,18 @@ recording:
 chromium:
   cpu: ""
   memory: ""
-
+  limits:
+    cpu: ""
+    memory: ""
 
 # Sockets configurations
 sockets:
   replicas: 1
   cpu: ""
   memory: ""
+  limits:
+    cpu: ""
+    memory: "" 
   debug: ""
 
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -42,8 +42,6 @@ image:
 
 # API configurations
 api:
-  image:
-    ref: ghcr.io/cobrowseio/cobrowse-api-enterprise:1.73.0 
   replicas: 1
   cpu: ""
   memory: ""


### PR DESCRIPTION
Adds to values:

- limits settings to cpu and memory of all components
- customTemplateSpec as custom block shared across all components to allow custom spec to be set, like in the case of nodeSelectors for architecture

Adjusts:

- Ingress annotation order
- defaultSecurityContext whitespace
- frontend serviceAccountName whitespace