### PR TITLE
fix: replica defaults and recording pdb

### DIFF
--- a/templates/recording-poddisruptionbudget.yaml
+++ b/templates/recording-poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: recording-pdb
 spec:
-  minAvailable: "50%"
+  minAvailable: {{ ternary "50%" 0 (ge  (int .Values.recording.replicas) 2) }}
   selector:
     matchLabels:
       component: recording

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -15,7 +15,6 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-sockets-headless
-  # default to 2 given the PodDisruptionBudget set to minAvailable: 1
   replicas: {{ .Values.sockets.replicas | default "2" }}
   selector:
     matchLabels:

--- a/values.yaml
+++ b/values.yaml
@@ -43,7 +43,7 @@ image:
 
 # API configurations
 api:
-  replicas: 1
+  replicas: 2
   cpu: ""
   memory: ""
   limits:
@@ -57,7 +57,7 @@ api:
 
 # Frontend configurations
 frontend:
-  replicas: 1
+  replicas: 2
   cpu: ""
   memory: ""
   limits:
@@ -70,7 +70,7 @@ frontend:
 
 # Proxy configurations
 proxy:
-  replicas: 1
+  replicas: 2
   cpu: ""
   memory: ""
   limits:
@@ -85,7 +85,7 @@ proxy:
 
 # Recording configurations
 recording:
-  replicas: 1
+  replicas: 2
   cpu: ""
   memory: ""
   limits:
@@ -110,7 +110,7 @@ chromium:
 
 # Sockets configurations
 sockets:
-  replicas: 1
+  replicas: 2
   cpu: ""
   memory: ""
   limits:


### PR DESCRIPTION
Aligned with https://docs.cobrowse.io/enterprise-self-hosting/helm/optional-recording-components#disable-recording-pods and the new PDB settings.