### PR TITLE
fix: allow the number of replicas to be 0

### DIFF
--- a/templates/api-deployment.yaml
+++ b/templates/api-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ .Values.api.replicas | default "2" }}
+  replicas: {{ .Values.api.replicas | default "0" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/templates/frontend-deployment.yaml
+++ b/templates/frontend-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ .Values.frontend.replicas | default "2" }}
+  replicas: {{ .Values.frontend.replicas | default "0" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/templates/sdk-js-deployment.yaml
+++ b/templates/sdk-js-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ .Values.sdkJs.replicas | default "2" }}
+  replicas: {{ .Values.sdkJs.replicas | default "0" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/templates/sockets-statefulset.yaml
+++ b/templates/sockets-statefulset.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-sockets-headless
-  replicas: {{ .Values.sockets.replicas | default "2" }}
+  replicas: {{ .Values.sockets.replicas | default "0" }}
   selector:
     matchLabels:
       component: sockets

--- a/templates/virtual-agent-deployment.yaml
+++ b/templates/virtual-agent-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ .Values.virtualAgent.replicas | default "2" }}
+  replicas: {{ .Values.virtualAgent.replicas | default "0" }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/tests/api-deployment_test.yaml
+++ b/tests/api-deployment_test.yaml
@@ -14,6 +14,15 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: may run no replicas
+    set:
+      api.replicas: 0
+    template: templates/api-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       api.replicas: 3

--- a/tests/frontend-deployment_test.yaml
+++ b/tests/frontend-deployment_test.yaml
@@ -14,6 +14,15 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: may run no replicas
+    set:
+      frontend.replicas: 0
+    template: templates/frontend-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       frontend.replicas: 3

--- a/tests/proxy-deployment_test.yaml
+++ b/tests/proxy-deployment_test.yaml
@@ -14,6 +14,15 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: may run no replicas
+    set:
+      proxy.replicas: 0
+    template: templates/proxy-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       proxy.replicas: 3

--- a/tests/recording-deployment_test.yaml
+++ b/tests/recording-deployment_test.yaml
@@ -21,6 +21,15 @@ tests:
           path: spec.template.spec.containers
           count: 2
 
+  - it: may run no replicas
+    set:
+      recording.replicas: 0
+    template: templates/recording-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       recording.replicas: 3

--- a/tests/sockets-statefulset_test.yaml
+++ b/tests/sockets-statefulset_test.yaml
@@ -14,6 +14,15 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: may run no replicas
+    set:
+      sockets.replicas: 0
+    template: templates/sockets-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       sockets.replicas: 3

--- a/tests/virtual-agent-deployment_test.yaml
+++ b/tests/virtual-agent-deployment_test.yaml
@@ -14,6 +14,15 @@ tests:
           path: spec.replicas
           value: 2
 
+  - it: may run no replicas
+    set:
+      virtualAgent.replicas: 0
+    template: templates/virtual-agent-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
   - it: may run multiple replicas
     set:
       virtualAgent.replicas: 3

--- a/values.schema.json
+++ b/values.schema.json
@@ -423,7 +423,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]
@@ -607,7 +607,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]
@@ -784,7 +784,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]
@@ -971,7 +971,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]
@@ -1184,7 +1184,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]
@@ -1405,7 +1405,7 @@
                     "type": "integer",
                     "title": "The replicas schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": 0,
+                    "default": 2,
                     "examples": [
                         1
                     ]


### PR DESCRIPTION
The helm chart is ignoring setting the number of replicas to 0 because helm templates treat 0 as an empty value. For example, setting the virtual_agent_count in terraform to 0 still spins up 2 replicas.

We specify the default number of replicas in the values.yaml so we should not need to do it in the deployment templates as well.